### PR TITLE
fix: correct match-statement arity in outputs.py (unblocks develop)

### DIFF
--- a/aTrain_core/outputs.py
+++ b/aTrain_core/outputs.py
@@ -63,13 +63,13 @@ def create_txt_file(result, file_id, speaker_detection, timestamps, maxqda, brac
     """Creates a TXT file for the transcription result."""
     segments = result["segments"]
     match maxqda, timestamps, brackets:
-        case True, _:
+        case True, _, _:
             filename = "transcription_maxqda.txt"
-        case False, True False:
-            filename = "transcription_nvivo.txt" #New: Nvivo format without timestamp brackets
+        case False, True, False:
+            filename = "transcription_nvivo.txt"  # NVivo format: timestamps without brackets
         case False, True, True:
             filename = "transcription_timestamps.txt"
-        case False, False:
+        case False, False, _:
             filename = "transcription.txt"
     file_path = os.path.join(TRANSCRIPT_DIR, file_id, filename)
     with open(file_path, "w", encoding="utf-8") as file:


### PR DESCRIPTION
`develop` cannot be imported right now because of a `SyntaxError` in
`outputs.py`:

```python
case False, True False:    # missing comma → SyntaxError
```

Introduced in #41 (`40a94fa`) when the `match` subject was widened
from a 2-tuple to a 3-tuple (added `brackets`). Three of the four
case arms weren't updated to match the new arity:

```python
match maxqda, timestamps, brackets:
    case True, _:              # 2-elem on 3-tuple → never matches
    case False, True False:    # SyntaxError
    case False, True, True:    # OK
    case False, False:         # 2-elem on 3-tuple → never matches
```

Even patching only the syntax error would leave three of four calls
from `create_output_files()` silently missing every arm and raising
`UnboundLocalError: filename`. So this PR widens all four patterns
to 3 elements. The 4 call sites in `create_output_files()` now route
to the intended filenames (verified by stepping each tuple through
the new `match`).

cc @gerardo-navarro