### PR TITLE
fix: pin torchaudio to match torch (ABI coupling)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dependencies = [
   "torch==2.8.0+cu128; sys_platform == 'win32'",
   "torch==2.9.1; sys_platform == 'linux'",
   "torch==2.8.0; sys_platform == 'darwin'",
+  # torchaudio must match torch (ABI-coupled); keep in lockstep with the pins above.
+  "torchaudio==2.8.0+cu128; sys_platform == 'win32'",
+  "torchaudio==2.9.1; sys_platform == 'linux'",
+  "torchaudio==2.8.0; sys_platform == 'darwin'",
   "typer==0.16.0",
   "platformdirs==4.5.1",
 ]


### PR DESCRIPTION
Fixes #47

### Problem
`torchaudio` is not declared as a dependency — it arrives transitively (via `pyannote.audio`, `torch-audiomentations`, `torch-pitch-shift`) and is left unconstrained. Since `torchaudio` is ABI-coupled to a specific `torch` build, a fresh resolve pairs the pinned `torch==2.9.1` (linux) with `torchaudio==2.11.0`, and `import torchaudio` (reached on startup via `aTrain_core.transcribe`) crashes:

```
OSError: .../torchaudio/lib/_torchaudio.abi3.so: undefined symbol: torch_library_impl
```

This makes a fresh install unusable for downstream consumers (e.g. the `aTrain` app) without a manual torchaudio pin.

### Fix
Pin `torchaudio` per-platform in lockstep with the existing `torch` pins (same versions, same markers).

### Why this won't reintroduce #30
#30 ("Cannot install torchaudio==2.2.0") was a *standalone* hard pin whose wheel didn't exist for newer Python, independent of how `torch` resolves. This pin instead mirrors the `torch` pins that already install cleanly today — on linux a bare `==2.9.1` (no local `+cuXXX` tag, no fixed-Python ABI) that resolves through the consumer's PyTorch index exactly as `torch==2.9.1` does. If the `torch` pin is bumped later, bump the matching `torchaudio` line in lockstep.

### Verification
Reproduced in isolation with a throwaway project whose only dependency is `aTrain_core@develop` (plus the cu128 index). On Linux/Python 3.12 it resolves `torch 2.9.1+cu128` with `torchaudio 2.11.0+cu128` and `import torchaudio` fails as above. With this change it re-resolves to `torchaudio 2.9.1+cu128` and both `import torchaudio` and `import aTrain_core` succeed.

cc @gerardo-navarro
