### PR TITLE
chore: update torch to 2.9.1 and pyannote.audio to 4.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,18 +27,15 @@ requires-python = ">=3.11"
 dependencies = [
   "faster-whisper==1.2.1",
   "pandas==2.3.3",
-  "pyannote.audio==4.0.3; sys_platform != 'linux'",
-  "pyannote.audio>4.0.3; sys_platform == 'linux'",
+  "pyannote.audio==4.0.4",
   "numpy==2.2.2",
   "werkzeug==3.0.3",
   "huggingface-hub==0.30.2",
-  "torch==2.8.0+cu128; sys_platform == 'win32'",
-  "torch==2.9.1; sys_platform == 'linux'",
-  "torch==2.8.0; sys_platform == 'darwin'",
+  "torch==2.9.1+cu130; sys_platform == 'win32'",
+  "torch==2.9.1; sys_platform != 'win32'",
   # torchaudio must match torch (ABI-coupled); keep in lockstep with the pins above.
-  "torchaudio==2.8.0+cu128; sys_platform == 'win32'",
-  "torchaudio==2.9.1; sys_platform == 'linux'",
-  "torchaudio==2.8.0; sys_platform == 'darwin'",
+  "torchaudio==2.9.1+cu130; sys_platform == 'win32'",
+  "torchaudio==2.9.1; sys_platform != 'win32'",
   "typer==0.16.0",
   "platformdirs==4.5.1",
 ]


### PR DESCRIPTION
Updates torch (and torchaudio plus cuda) to newest versions; also update pyannote.audio to newest version.

This updates everything for https://github.com/JuergenFleiss/aTrain/issues/159